### PR TITLE
[TECHPACK-AUDIO] [7.1.r1] Implement SoMC Kumano support

### DIFF
--- a/asoc/codecs/wcd-mbhc-adc.c
+++ b/asoc/codecs/wcd-mbhc-adc.c
@@ -369,7 +369,7 @@ static bool wcd_mbhc_adc_check_for_spl_headset(struct wcd_mbhc *mbhc,
 				mbhc->mbhc_cfg->mbhc_micbias, true);
 	usleep_range(10000, 10100);
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 	/* Wait for debounce time 200ms for extension cable */
 	if (mbhc->extn_cable_inserted)
 		msleep(200);
@@ -597,7 +597,7 @@ static int wcd_mbhc_get_plug_from_adc(struct wcd_mbhc *mbhc, int adc_result)
 		hph_thr = WCD_MBHC_ADC_HPH_THRESHOLD_MV;
 
 	if (adc_result < hph_thr)
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 		if (mbhc->force_linein)
 			plug_type = MBHC_PLUG_TYPE_HIGH_HPH;
 		else
@@ -837,7 +837,7 @@ correct_plug_type:
 		}
 	}
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 	if (plug_type == MBHC_PLUG_TYPE_HIGH_HPH &&
 	    !mbhc->force_linein) {
 #else
@@ -1097,7 +1097,7 @@ static irqreturn_t wcd_mbhc_adc_hs_ins_irq(int irq, void *data)
 	WCD_MBHC_REG_UPDATE_BITS(WCD_MBHC_ELECT_SCHMT_ISRC, 0);
 	WCD_MBHC_REG_UPDATE_BITS(WCD_MBHC_ELECT_ISRC_EN, 0);
 	mbhc->is_extn_cable = true;
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 	mbhc->extn_cable_inserted = true;
 #endif
 	mbhc->btn_press_intr = false;

--- a/asoc/codecs/wcd-mbhc-v2.c
+++ b/asoc/codecs/wcd-mbhc-v2.c
@@ -560,7 +560,7 @@ void wcd_mbhc_report_plug(struct wcd_mbhc *mbhc, int insertion,
 	u8 fsm_en = 0;
 
 #if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE) || \
-    defined(CONFIG_ARCH_SONY_TAMA)
+    defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 	bool skip_report = false;
 #endif
 
@@ -603,7 +603,7 @@ void wcd_mbhc_report_plug(struct wcd_mbhc *mbhc, int insertion,
 		}
 
 		mbhc->hph_type = WCD_MBHC_HPH_NONE;
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 		mbhc->extn_cable_inserted = false;
 #endif
 		mbhc->zl = mbhc->zr = 0;
@@ -686,7 +686,7 @@ void wcd_mbhc_report_plug(struct wcd_mbhc *mbhc, int insertion,
 		} else if (jack_type == SND_JACK_LINEOUT) {
 			mbhc->current_plug = MBHC_PLUG_TYPE_HIGH_HPH;
 #if defined(CONFIG_ARCH_SONY_LOIRE) || defined (CONFIG_ARCH_SONY_TONE) || \
-    defined(CONFIG_ARCH_SONY_TAMA)
+    defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 			skip_report = true;
 #endif
 		} else if (jack_type == SND_JACK_ANC_HEADPHONE)
@@ -710,9 +710,9 @@ void wcd_mbhc_report_plug(struct wcd_mbhc *mbhc, int insertion,
 			WCD_MBHC_REG_UPDATE_BITS(WCD_MBHC_FSM_EN,
 						 fsm_en);
 #if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE) || \
-    defined(CONFIG_ARCH_SONY_TAMA)
+    defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 
- #ifndef CONFIG_ARCH_SONY_TAMA
+ #if !defined(CONFIG_ARCH_SONY_TAMA) && !defined(CONFIG_ARCH_SONY_KUMANO)
 			if (mbhc->zl > mbhc->mbhc_cfg->linein_th &&
 			    jack_type == SND_JACK_ANC_HEADPHONE) {
 				jack_type = SND_JACK_STEREO_MICROPHONE;
@@ -755,7 +755,7 @@ void wcd_mbhc_report_plug(struct wcd_mbhc *mbhc, int insertion,
 		pr_debug("%s: Reporting insertion %d(%x)\n", __func__,
 			 jack_type, mbhc->hph_status);
 #if defined(CONFIG_ARCH_SONY_LOIRE) || defined (CONFIG_ARCH_SONY_TONE) || \
-    defined(CONFIG_ARCH_SONY_TAMA)
+    defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 		if (!skip_report)
 #endif
 		wcd_mbhc_jack_report(mbhc, &mbhc->headset_jack,
@@ -2065,7 +2065,7 @@ int wcd_mbhc_init(struct wcd_mbhc *mbhc, struct snd_soc_codec *codec,
 	mbhc->is_hs_recording = false;
 	mbhc->is_extn_cable = false;
 	mbhc->extn_cable_hph_rem = false;
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 	mbhc->extn_cable_inserted = false;
 #endif
 	mbhc->hph_type = WCD_MBHC_HPH_NONE;

--- a/asoc/codecs/wcd-mbhc-v2.h
+++ b/asoc/codecs/wcd-mbhc-v2.h
@@ -25,7 +25,7 @@
 #define WCD_MBHC_USLEEP_RANGE_MARGIN_US 100
 #if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE)
  #define WCD_MBHC_THR_HS_MICB_MV	2450
-#elif defined(CONFIG_ARCH_SONY_TAMA)
+#elif defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
  #define WCD_MBHC_THR_HS_MICB_MV	2750
 #else
  #define WCD_MBHC_THR_HS_MICB_MV  2700
@@ -156,7 +156,7 @@ do {                                                    \
 #define FAKE_REM_RETRY_ATTEMPTS 3
 #define MAX_IMPED 60000
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
  #undef GND_MIC_SWAP_THRESHOLD
  #undef WCD_FAKE_REMOVAL_MIN_PERIOD_MS
  #undef FAKE_REM_RETRY_ATTEMPTS
@@ -578,7 +578,7 @@ struct wcd_mbhc {
 	bool btn_press_intr;
 	bool is_hs_recording;
 	bool is_extn_cable;
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 	bool extn_cable_inserted;
 #endif
 	bool skip_imped_detection;

--- a/asoc/codecs/wcd934x/wcd934x-mbhc.c
+++ b/asoc/codecs/wcd934x/wcd934x-mbhc.c
@@ -35,6 +35,14 @@
 #include "../wcdcal-hwdep.h"
 #include "../wcd-mbhc-v2-api.h"
 
+#ifdef AUDIO_SONY_PLATFORM
+  #undef AUDIO_SONY_PLATFORM
+#endif
+
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
+  #define AUDIO_SONY_PLATFORM 1
+#endif
+
 #define TAVIL_ZDET_SUPPORTED          true
 /* Z value defined in milliohm */
 #define TAVIL_ZDET_VAL_32             32000
@@ -493,7 +501,7 @@ static inline void tavil_mbhc_get_result_params(struct wcd9xxx *wcd9xxx,
 	if ((c1 < 2) && x1)
 		usleep_range(5000, 5050);
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 	if (!c1) {
 #else
 	if (!c1 || !x1) {

--- a/asoc/codecs/wcd934x/wcd934x.c
+++ b/asoc/codecs/wcd934x/wcd934x.c
@@ -51,6 +51,14 @@
 #include "../wcdcal-hwdep.h"
 #include "wcd934x-dsd.h"
 
+#ifdef AUDIO_SONY_PLATFORM
+  #undef AUDIO_SONY_PLATFORM
+#endif
+
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
+  #define AUDIO_SONY_PLATFORM 1
+#endif
+
 #define WCD934X_RATES_MASK (SNDRV_PCM_RATE_8000 | SNDRV_PCM_RATE_16000 |\
 			    SNDRV_PCM_RATE_32000 | SNDRV_PCM_RATE_48000 |\
 			    SNDRV_PCM_RATE_96000 | SNDRV_PCM_RATE_192000 |\
@@ -3913,7 +3921,7 @@ static int tavil_codec_set_idle_detect_thr(struct snd_soc_codec *codec,
 	return 0;
 }
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 static void tavil_codec_set_offset_val(int *offset_val, int gain_offset,
 				       int mult)
 {
@@ -3965,7 +3973,7 @@ static int tavil_codec_enable_mix_path(struct snd_soc_dapm_widget *w,
 		snd_soc_update_bits(codec, mix_reg, 0x20, 0x20);
 		break;
 	case SND_SOC_DAPM_POST_PMU:
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 		if ((tavil->swr.spkr_gain_offset ==
 		     WCD934X_RX_GAIN_OFFSET_0_DB) &&
 #else
@@ -3986,7 +3994,7 @@ static int tavil_codec_enable_mix_path(struct snd_soc_dapm_widget *w,
 			snd_soc_update_bits(codec,
 					    WCD934X_CDC_RX8_RX_PATH_MIX_SEC0,
 					    0x01, 0x01);
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 			tavil_codec_set_offset_val(&offset_val,
 						   tavil->swr.spkr_gain_offset, -1);
 #else
@@ -4006,7 +4014,7 @@ static int tavil_codec_enable_mix_path(struct snd_soc_dapm_widget *w,
 		snd_soc_update_bits(codec, mix_reg, 0x40, 0x40);
 		snd_soc_update_bits(codec, mix_reg, 0x40, 0x00);
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 		if ((tavil->swr.spkr_gain_offset ==
 		     WCD934X_RX_GAIN_OFFSET_0_DB) &&
 #else
@@ -4027,7 +4035,7 @@ static int tavil_codec_enable_mix_path(struct snd_soc_dapm_widget *w,
 			snd_soc_update_bits(codec,
 					    WCD934X_CDC_RX8_RX_PATH_MIX_SEC0,
 					    0x01, 0x00);
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 			tavil_codec_set_offset_val(&offset_val,
 						   tavil->swr.spkr_gain_offset, 1);
 #else
@@ -4101,7 +4109,7 @@ static int tavil_codec_enable_main_path(struct snd_soc_dapm_widget *w,
 		break;
 	case SND_SOC_DAPM_POST_PMU:
 		/* apply gain after int clk is enabled */
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 		if ((tavil->swr.spkr_gain_offset ==
 		     			WCD934X_RX_GAIN_OFFSET_0_DB) &&
 #else
@@ -4122,7 +4130,7 @@ static int tavil_codec_enable_main_path(struct snd_soc_dapm_widget *w,
 			snd_soc_update_bits(codec,
 					    WCD934X_CDC_RX8_RX_PATH_MIX_SEC0,
 					    0x01, 0x01);
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 			tavil_codec_set_offset_val(&offset_val,
 						   tavil->swr.spkr_gain_offset, -1);
 #else
@@ -4137,7 +4145,7 @@ static int tavil_codec_enable_main_path(struct snd_soc_dapm_widget *w,
 	case SND_SOC_DAPM_POST_PMD:
 		tavil_codec_enable_interp_clk(codec, event, w->shift);
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 		if ((tavil->swr.spkr_gain_offset ==
 		     			WCD934X_RX_GAIN_OFFSET_0_DB) &&
 #else
@@ -4158,7 +4166,7 @@ static int tavil_codec_enable_main_path(struct snd_soc_dapm_widget *w,
 			snd_soc_update_bits(codec,
 					    WCD934X_CDC_RX8_RX_PATH_MIX_SEC0,
 					    0x01, 0x00);
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 			tavil_codec_set_offset_val(&offset_val,
 						   tavil->swr.spkr_gain_offset, 1);
 #else
@@ -9594,7 +9602,7 @@ static const struct tavil_reg_mask_val tavil_codec_reg_init_common_val[] = {
 	{WCD934X_MICB2_TEST_CTL_1, 0xff, 0xfa},
 	{WCD934X_MICB3_TEST_CTL_1, 0xff, 0xfa},
 	{WCD934X_MICB4_TEST_CTL_1, 0xff, 0xfa},
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 	{WCD934X_CDC_RX3_RX_PATH_CFG1, 0x64, 0x00}
 #endif
 };
@@ -11195,7 +11203,7 @@ static int tavil_probe(struct platform_device *pdev)
 	tavil->swr.plat_data.handle_irq = tavil_swrm_handle_irq;
 	tavil->swr.spkr_gain_offset = WCD934X_RX_GAIN_OFFSET_0_DB;
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 	tavil->swr.spkr_gain_offset = WCD934X_RX_GAIN_OFFSET_M0P5_DB;
 #endif
 

--- a/asoc/codecs/wcd934x/wcd934x.h
+++ b/asoc/codecs/wcd934x/wcd934x.h
@@ -19,6 +19,14 @@
 #include "../wcd9xxx-common-v2.h"
 #include "../wcd-mbhc-v2.h"
 
+#ifdef AUDIO_SONY_PLATFORM
+  #undef AUDIO_SONY_PLATFORM
+#endif
+
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
+  #define AUDIO_SONY_PLATFORM 1
+#endif
+
 #define WCD934X_REGISTER_START_OFFSET  0x800
 #define WCD934X_SB_PGD_PORT_RX_BASE   0x40
 #define WCD934X_SB_PGD_PORT_TX_BASE   0x50
@@ -116,7 +124,7 @@ enum {
  */
 enum {
 	WCD934X_RX_GAIN_OFFSET_M1P5_DB,
-#ifdef CONFIG_ARCH_SONY_TAMA
+#ifdef AUDIO_SONY_PLATFORM
 	WCD934X_RX_GAIN_OFFSET_M0P5_DB,
 #endif
 	WCD934X_RX_GAIN_OFFSET_0_DB,

--- a/asoc/codecs/wcd_cpe_core.c
+++ b/asoc/codecs/wcd_cpe_core.c
@@ -827,7 +827,7 @@ static int wcd_cpe_enable(struct wcd_cpe_core *core,
 		bool enable)
 {
 	int ret = 0;
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 	int timeout = 0;
 	int err_cnt = 0;
 #endif
@@ -854,7 +854,7 @@ static int wcd_cpe_enable(struct wcd_cpe_core *core,
 			goto fail_boot;
 
 		/* Dload data section */
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 		for (err_cnt = 0; err_cnt < 10; err_cnt++) {
 			/* Dload data section */
 			ret = wcd_cpe_load_fw(core, ELF_FLAG_RW);
@@ -900,7 +900,7 @@ static int wcd_cpe_enable(struct wcd_cpe_core *core,
 			"%s: waiting for CPE bootup\n",
 			__func__);
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+#if defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_KUMANO)
 		timeout = wait_for_completion_timeout(&core->online_compl,
 						msecs_to_jiffies(1000));
 		if (!timeout) {

--- a/asoc/codecs/wsa881x.c
+++ b/asoc/codecs/wsa881x.c
@@ -1098,6 +1098,8 @@ static void wsa881x_init(struct snd_soc_codec *codec)
 				    0xF0, 0x30);
 #elif defined(CONFIG_ARCH_SONY_TAMA)
 				    0xF0, 0x7F);
+#elif defined(CONFIG_ARCH_SONY_KUMANO)
+				    0xF0, 0x7B);
 #else
 				    0xF0, 0x70);
 #endif

--- a/asoc/sm8150.c
+++ b/asoc/sm8150.c
@@ -4294,8 +4294,17 @@ static void *def_wcd_mbhc_cal(void)
 	if (!wcd_mbhc_cal)
 		return NULL;
 
-#define S(X, Y) ((WCD_MBHC_CAL_PLUG_TYPE_PTR(wcd_mbhc_cal)->X) = (Y))
-	S(v_hs_max, 1600);
+#ifdef CONFIG_ARCH_SONY_KUMANO
+ #define VHSMAX 1700
+ #define BTN_H1 137
+#else
+ #define VHSMAX 1600
+ #define BTN_H1 150
+#endif
+
+#define S(X, Y) ((WCD_MBHC_CAL_PLUG_TYPE_PTR(tavil_wcd_cal)->X) = (Y))
+	S(v_hs_max, VHSMAX);
+#undef S
 #undef S
 #define S(X, Y) ((WCD_MBHC_CAL_BTN_DET_PTR(wcd_mbhc_cal)->X) = (Y))
 	S(num_btn, WCD_MBHC_DEF_BUTTONS);
@@ -4306,7 +4315,7 @@ static void *def_wcd_mbhc_cal(void)
 		(sizeof(btn_cfg->_v_btn_low[0]) * btn_cfg->num_btn);
 
 	btn_high[0] = 75;
-	btn_high[1] = 150;
+	btn_high[1] = BTN_H1;
 	btn_high[2] = 237;
 	btn_high[3] = 500;
 	btn_high[4] = 500;


### PR DESCRIPTION
The SoMC Kumano platform didn't have its specific code paths in the
audio techpack on 7.1.r1 branch.

Extend the SoMC Tama platform codepaths to Kumano (as it requires
the same stuff) and add the mbhc configuration for SM8150 specific.