### PR TITLE
[7.1.r1] [TECHPACK-AUDIO] include: uapi: Fix build for Android HALs with advanced functionalities

### DIFF
--- a/include/uapi/sound/devdep_params.h
+++ b/include/uapi/sound/devdep_params.h
@@ -1,6 +1,12 @@
 #ifndef _DEV_DEP_H
 #define _DEV_DEP_H
 
+#ifndef __KERNEL__
+ #ifndef __user
+  #define __user
+ #endif
+#endif
+
 struct dolby_param_data {
 	int32_t version;
 	int32_t device_id;

--- a/include/uapi/sound/msmcal-hwdep.h
+++ b/include/uapi/sound/msmcal-hwdep.h
@@ -1,6 +1,12 @@
 #ifndef _CALIB_HWDEP_H
 #define _CALIB_HWDEP_H
 
+#ifndef __KERNEL__
+ #ifndef __user
+  #define __user
+ #endif
+#endif
+
 #define WCD9XXX_CODEC_HWDEP_NODE    1000
 #define AQT1000_CODEC_HWDEP_NODE    1001
 #define Q6AFE_HWDEP_NODE    1002


### PR DESCRIPTION
The Android HALs for media/audio with advanced functionalities do
include the devdep_params and msmcal-hwdep headers, but the __user
word is not defined in the userspace case (since it's defined only
in kernel, for kernel building): fix this usecase.