### PR TITLE
[7.1.r1] [TECHPACK-AUDIO] asoc: sm8150: Fix typo in S(X, Y) macro

### DIFF
--- a/asoc/sm8150.c
+++ b/asoc/sm8150.c
@@ -4302,7 +4302,7 @@ static void *def_wcd_mbhc_cal(void)
  #define BTN_H1 150
 #endif
 
-#define S(X, Y) ((WCD_MBHC_CAL_PLUG_TYPE_PTR(tavil_wcd_cal)->X) = (Y))
+#define S(X, Y) ((WCD_MBHC_CAL_PLUG_TYPE_PTR(wcd_mbhc_cal)->X) = (Y))
 	S(v_hs_max, VHSMAX);
 #undef S
 #undef S


### PR DESCRIPTION
The PLUG TYPE S(X, Y) macro was copypasted from sdm845 and
was erroneously using the wrong variable name, leading to a
build failure.

Fix the typo.