### PR TITLE
[LA.UM.7.1.r1] msm_audio_calibration: Enable TOPOLOGY_SPECIFIC_CHANNEL_INFO for SM8150

### DIFF
--- a/include/uapi/linux/msm_audio_calibration.h
+++ b/include/uapi/linux/msm_audio_calibration.h
@@ -122,9 +122,10 @@ enum {
 /*
  * The firmware on the legacy targets does not support this feature
  */
-#if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996) || \
-	defined(CONFIG_ARCH_MSM8998) || defined(CONFIG_ARCH_SDM630) ||  \
-	defined(CONFIG_ARCH_SDM660)  || defined(CONFIG_ARCH_SDM845)
+#if !(defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8956)   || \
+	defined(CONFIG_ARCH_MSM8996) || defined(CONFIG_ARCH_MSM8998) || \
+	defined(CONFIG_ARCH_SDM630)  || defined(CONFIG_ARCH_SDM660)  || \
+	defined(CONFIG_ARCH_SDM845))
 	#define TOPOLOGY_SPECIFIC_CHANNEL_INFO
 #endif
 

--- a/include/uapi/linux/msm_audio_calibration.h
+++ b/include/uapi/linux/msm_audio_calibration.h
@@ -451,10 +451,8 @@ struct audio_cal_info_lsm {
 struct audio_cal_info_voc_top {
 	int32_t		topology;
 	int32_t		acdb_id;
-#ifdef TOPOLOGY_SPECIFIC_CHANNEL_INFO
 	uint32_t	num_channels;
 	uint8_t		channel_mapping[VSS_NUM_CHANNELS_MAX];
-#endif
 };
 
 struct audio_cal_info_vocproc {


### PR DESCRIPTION
Closes https://github.com/sonyxperiadev/bug_tracker/issues/500

SM8150 is not a legacy target as the comment describes, and the absence
of this define causes a build failure in q6voice which uses this
topology feature while structure members in audio_cal_info_voc_top have
not been defined.

Shouldn't we instead base this feature on the presence of `CONFIG_SND_SOC_MSM_QDSP6V2_INTF` or a related feature? All devices/platforms with this option compile q6 which uses the topology info unconditionally.