### PR TITLE
[LA.UM.7.1.r1] HACK: sdm660 analog cdc: Shorten cdc-vdd-mic-bias supply name.

### DIFF
--- a/asoc/codecs/sdm660_cdc/msm-analog-cdc.c
+++ b/asoc/codecs/sdm660_cdc/msm-analog-cdc.c
@@ -87,7 +87,7 @@ static struct snd_soc_dai_driver msm_anlg_cdc_i2s_dai[];
 static bool spkr_boost_en = true;
 
 static char on_demand_supply_name[][MAX_ON_DEMAND_SUPPLY_NAME_LENGTH] = {
-	"cdc-vdd-mic-bias",
+	"cdc-vdd-mbias",
 };
 
 static struct wcd_mbhc_register


### PR DESCRIPTION
For https://github.com/sonyxperiadev/kernel/pull/2174

The regulator core cannot handle a longer name when combined with the
full nested path of the DT node representing msm-analog-cdc. The name of
this property has been shortened in the DT, but needs to be shortened in
the driver as well to be able to find it.