### PR TITLE
[TP-AUDIO] [7.1.r1] Fix AVTIMER and improve audio quality on supported DSPs

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -106,6 +106,8 @@ config WCD_DSP_GLINK
 	tristate "WCD_DSP_GLINK"
 config MSM_AVTIMER
 	tristate "MSM_AVTIMER"
+config MSM_AVTIMER_LEGACY
+	tristate "MSM_AVTIMER_LEGACY"
 config SND_SOC_SDM660_CDC
 	tristate "SND_SOC_SDM660_CDC"
 config SND_SOC_ANALOG_CDC

--- a/dsp/q6adm.c
+++ b/dsp/q6adm.c
@@ -49,6 +49,9 @@
 #define DS2_ADM_COPP_TOPOLOGY_ID 0xFFFFFFFF
 #endif
 
+#define APPTYPE_GENERAL_PLAYBACK 0x00011130
+#define APPTYPE_SYSTEM_SOUNDS 0x00011131
+
 /* ENUM for adm_status */
 enum adm_cal_status {
 	ADM_STATUS_CALIBRATION_REQUIRED = 0,
@@ -2843,6 +2846,15 @@ int adm_open(int port_id, int path, int rate, int channel_mode, int topology,
 	pr_debug("%s:port %#x path:%d rate:%d mode:%d perf_mode:%d,topo_id %d\n",
 		 __func__, port_id, path, rate, channel_mode, perf_mode,
 		 topology);
+
+#if defined(CONFIG_ARCH_SONY_NILE) || defined (CONFIG_ARCH_SONY_GANGES) || \
+    defined(CONFIG_ARCH_SONY_KUMANO)
+	if (path == ADM_PATH_PLAYBACK || app_type == APPTYPE_GENERAL_PLAYBACK ||
+	    app_type == APPTYPE_SYSTEM_SOUNDS) {
+		pr_info("%s: Force 24-bits audio for APPTYPE 0x%x\n", __func__, app_type);
+		bit_width = 24;
+	}
+#endif
 
 	port_id = q6audio_convert_virtual_to_portid(port_id);
 	port_idx = adm_validate_and_get_port_index(port_id);

--- a/dsp/q6asm.c
+++ b/dsp/q6asm.c
@@ -3453,7 +3453,8 @@ static int __q6asm_open_write(struct audio_client *ac, uint32_t format,
 	open.sink_endpointype = ASM_END_POINT_DEVICE_MATRIX;
 	open.bits_per_sample = bits_per_sample;
 
-#if defined(CONFIG_ARCH_SONY_NILE) || defined(CONFIG_ARCH_SONY_GANGES)
+#if defined(CONFIG_ARCH_SONY_NILE) || defined(CONFIG_ARCH_SONY_GANGES) || \
+    defined(CONFIG_ARCH_SONY_KUMANO)
 	if (ac->perf_mode == LOW_LATENCY_PCM_MODE ||
 	    ac->perf_mode == ULTRA_LOW_LATENCY_PCM_MODE ||
 	    ac->perf_mode == ULL_POST_PROCESSING_PCM_MODE)


### PR DESCRIPTION
Fix AVTIMER for legacy devices, improve audio quality on supported DSPs
by forcing 24-bit audio in order to get the right DSP path after sending the
ACDB calibration.

Reason for this is that the ACDB calibration for some platforms, including
SoMC Kumano and SoMC Nile/Ganges, is referred to 24-bits audio, not to
16-bits.
