### PR TITLE
[LA.UM.7.1.r1] treewide: Kbuild: Remove unused `shell date` commands from macro defines

### DIFF
--- a/asoc/Kbuild
+++ b/asoc/Kbuild
@@ -214,6 +214,3 @@ machine_dlkm-y := $(MACHINE_OBJS)
 
 obj-$(CONFIG_SND_SOC_CPE) += cpe_lsm_dlkm.o
 cpe_lsm_dlkm-y := $(CPE_LSM_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/Kbuild
+++ b/asoc/codecs/Kbuild
@@ -230,6 +230,3 @@ mbhc_dlkm-y := $(MBHC_OBJS)
 
 obj-$(CONFIG_SND_SOC_MSM_HDMI_CODEC_RX) += hdmi_dlkm.o
 hdmi_dlkm-y := $(HDMICODEC_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/aqt1000/Kbuild
+++ b/asoc/codecs/aqt1000/Kbuild
@@ -119,6 +119,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_AQT1000) += aqt1000_cdc_dlkm.o
 aqt1000_cdc_dlkm-y := $(AQT1000_CDC_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/bolero/Kbuild
+++ b/asoc/codecs/bolero/Kbuild
@@ -143,6 +143,3 @@ tx_macro_dlkm-y := $(TX_OBJS)
 
 obj-$(CONFIG_RX_MACRO) += rx_macro_dlkm.o
 rx_macro_dlkm-y := $(RX_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/csra66x0/Kbuild
+++ b/asoc/codecs/csra66x0/Kbuild
@@ -104,6 +104,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_CSRA66X0) += csra66x0_dlkm.o
 csra66x0_dlkm-y := $(CSRA66X0_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/ep92/Kbuild
+++ b/asoc/codecs/ep92/Kbuild
@@ -105,6 +105,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_EP92) += ep92_dlkm.o
 ep92_dlkm-y := $(EP92_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/msm_sdw/Kbuild
+++ b/asoc/codecs/msm_sdw/Kbuild
@@ -114,6 +114,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_MSM_SDW) += msm_sdw_dlkm.o
 msm_sdw_dlkm-y := $(MSM_SDW_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/sdm660_cdc/Kbuild
+++ b/asoc/codecs/sdm660_cdc/Kbuild
@@ -120,6 +120,3 @@ analog_cdc_dlkm-y := $(ANALOG_CDC_OBJS)
 
 obj-$(CONFIG_SND_SOC_DIGITAL_CDC) += digital_cdc_dlkm.o
 digital_cdc_dlkm-y := $(DIGITAL_CDC_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/wcd934x/Kbuild
+++ b/asoc/codecs/wcd934x/Kbuild
@@ -135,6 +135,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_WCD934X) += wcd934x_dlkm.o
 wcd934x_dlkm-y := $(WCD934X_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/wcd9360/Kbuild
+++ b/asoc/codecs/wcd9360/Kbuild
@@ -109,6 +109,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_WCD9360) += wcd9360_dlkm.o
 wcd9360_dlkm-y := $(WCD9360_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/wcd937x/Kbuild
+++ b/asoc/codecs/wcd937x/Kbuild
@@ -117,6 +117,3 @@ wcd937x_dlkm-y := $(WCD937X_OBJS)
 
 obj-$(CONFIG_SND_SOC_WCD937X_SLAVE) += wcd937x_slave_dlkm.o
 wcd937x_slave_dlkm-y := $(WCD937X_SLAVE_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/dsp/Kbuild
+++ b/dsp/Kbuild
@@ -165,6 +165,3 @@ q6_pdr_dlkm-y := $(QDSP6_PDR_OBJS)
 
 obj-$(CONFIG_MSM_QDSP6_NOTIFIER) += q6_notifier_dlkm.o
 q6_notifier_dlkm-y := $(QDSP6_NOTIFIER_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/dsp/codecs/Kbuild
+++ b/dsp/codecs/Kbuild
@@ -157,6 +157,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_MSM_QDSP6V2_CODECS) += native_dlkm.o
 native_dlkm-y := $(NATIVE_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/ipc/Kbuild
+++ b/ipc/Kbuild
@@ -114,6 +114,3 @@ apr_dlkm-y := $(APRV_GLINK)
 
 obj-$(CONFIG_WCD_DSP_GLINK) += wglink_dlkm.o
 wglink_dlkm-y := $(WDSP_GLINK)
-
-# inject some build related information
-CDEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/soc/Kbuild
+++ b/soc/Kbuild
@@ -125,6 +125,3 @@ snd_event_dlkm-y := $(SND_EVENT_OBJS)
 obj-$(CONFIG_SOUNDWIRE_WCD_CTRL) += swr_ctrl_dlkm.o
 obj-$(CONFIG_SOUNDWIRE_MSTR_CTRL) += swr_ctrl_dlkm.o
 swr_ctrl_dlkm-y := $(SWR_CTRL_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"


### PR DESCRIPTION
This macro define changes every build due to the nature of datetime,
causing the build-system to needlessly recompile all source files every
time even though the macro is never referenced (grep for BUILD_TIMESTAMP).