### PR TITLE
[LA.UM.7.1.r1] Kconfig: AVTIMER_LEGACY dep on MSMB_CAMERA AVTIMER

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -108,6 +108,8 @@ config MSM_AVTIMER
 	tristate "MSM_AVTIMER"
 config MSM_AVTIMER_LEGACY
 	tristate "MSM_AVTIMER_LEGACY"
+	depends on MSMB_CAMERA
+	depends on MSM_AVTIMER
 config SND_SOC_SDM660_CDC
 	tristate "SND_SOC_SDM660_CDC"
 config SND_SOC_ANALOG_CDC


### PR DESCRIPTION
`CONFIG_MSM_AVTIMER_LEGACY` depends on `CONFIG_MSM_AVTIMER`.

The include `<media/msmb_isp.h>` depends on the definitions of `msm_isp_set_avtimer_fptr` in
`drivers/media/platform/msm/camera_v2/isp/msm_isp.c`, which is enabled by `CONFIG_MSMB_CAMERA`.

Build-tested on SoMC Kagura RoW.