### PR TITLE
Kconfig: Disable reenabling of -Wmaybe-uninitialized

### DIFF
--- a/asoc/codecs/Kbuild
+++ b/asoc/codecs/Kbuild
@@ -172,13 +172,6 @@ CDEFINES +=	-DANI_LITTLE_BYTE_ENDIAN \
 
 KBUILD_CPPFLAGS += $(CDEFINES)
 
-# Currently, for versions of gcc which support it, the kernel Makefile
-# is disabling the maybe-uninitialized warning.  Re-enable it for the
-# AUDIO driver.  Note that we must use EXTRA_CFLAGS here so that it
-# will override the kernel settings.
-ifeq ($(call cc-option-yn, -Wmaybe-uninitialized),y)
-EXTRA_CFLAGS += -Wmaybe-uninitialized
-endif
 #EXTRA_CFLAGS += -Wmissing-prototypes
 
 ifeq ($(call cc-option-yn, -Wheader-guard),y)


### PR DESCRIPTION
Currently the kconfig reenables -Wmaybe-uninitialized triggering
-Werror, disable that.