### PR TITLE
[9.12.r1] uapi/Android.mk: Add guard to build only on 4.19

### DIFF
--- a/include/uapi/Android.mk
+++ b/include/uapi/Android.mk
@@ -1,5 +1,6 @@
 # Use this by setting
 #   LOCAL_HEADER_LIBRARIES := audio_kernel_headers
+ifeq ($(SOMC_KERNEL_VERSION),4.19)
 
 LOCAL_PATH := $(call my-dir)
 MYLOCAL_PATH := $(LOCAL_PATH)
@@ -28,3 +29,4 @@ LOCAL_GENERATED_SOURCES := $(GEN)
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(UAPI_OUT)
 
 include $(BUILD_HEADER_LIBRARY)
+endif


### PR DESCRIPTION
Both 4.19 and 4.14 kernel define this module.
error:

    kernel/sony/msm-4.19/kernel/techpack/audio/include/uapi: MODULE.TARGET.HEADER_LIBRARIES.audio_kernel_headers
    already defined by kernel/sony/msm-4.14/kernel/techpack/audio/include/uapi.

Add a guard to allow to build this module only when 4.19 is selected
as the kernel to build in SOMC_KERNEL_VERSION.