### PR TITLE
[7.1] make: Disable unfixable CAF warnings-as-errors for newer compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,5 @@ obj-y += soc/
 obj-y += dsp/
 obj-y += ipc/
 obj-y += asoc/
+
+subdir-ccflags-y += -Wno-error=misleading-indentation -Wno-error=maybe-uninitialized -Wno-error=array-parameter


### PR DESCRIPTION
Newer compilers detect more and more mistakes in these vast codebases,
and they're disallowed with -Werror.  It is infeasible and a waste of
our time to fix them all, but we'd still like to use newer GCC.