### PR TITLE
[7.1] make: Use cc-option to check if -Wno-error excludes are available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,6 @@ obj-y += dsp/
 obj-y += ipc/
 obj-y += asoc/
 
-subdir-ccflags-y += -Wno-error=misleading-indentation -Wno-error=maybe-uninitialized -Wno-error=array-parameter
+subdir-ccflags-y += $(call cc-option,-Wno-error=array-parameter)
+subdir-ccflags-y += $(call cc-option,-Wno-error=maybe-uninitialized)
+subdir-ccflags-y += $(call cc-option,-Wno-error=misleading-indentation)


### PR DESCRIPTION
Unfortunately people are still on ancient compilers that are unaware of these specific warnings (hence why -Werror is not a problem to them) but this also means that the compiler fails on "unknown warning option".  Solve that by running through cc-option, which only passes the option if it's available.

Fixes: 4839d8e4 ("make: Disable unfixable CAF warnings-as-errors for newer compilers")

CC @voidanix
