### PR TITLE
[9.12.r1] make: Disable unfixable CAF warnings-as-errors for newer compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,11 @@ obj-y += soc/
 obj-y += dsp/
 obj-y += ipc/
 obj-y += asoc/
+
+
+ccflags_no-error_maybe_uninitialized := $(call cc-option,-Wno-error=maybe-uninitialized)
+ccflags_no-error_misleading_indentation := $(call cc-option,-Wno-error=misleading-indentation)
+ccflags_no-error_restrict := $(call cc-option,-Wno-error=restrict)
+ccflags_no-error_array_bounds := $(call cc-option,-Wno-error=array-bounds)
+
+subdir-ccflags-y := $(ccflags_no-error_array_parameter) $(ccflags_no-error_maybe_uninitialized) $(ccflags_no-error_misleading_indentation) $(ccflags_no-error_restrict) $(ccflags_no-error_array_bounds)


### PR DESCRIPTION
Newer compilers detect more and more mistakes in these vast codebases,
and they're disallowed with -Werror.  It is infeasible and a waste of
our time to fix them all, but we'd still like to use newer GCC.

Adjusted for Linux 4.19

Added two options found while testing with GCC 11.2.0:
+ -Wno-error=restrict
+ -Wno-error=array-bounds

Like https://github.com/sonyxperiadev/kernel/pull/2460 but for techpack-audio