### PR TITLE
Remove hard-coded kona detecting target board.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -3,7 +3,7 @@ MY_LOCAL_PATH := $(call my-dir)
 
 UAPI_OUT := $(PRODUCT_OUT)/obj/vendor/qcom/opensource/audio-kernel/include
 
-ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) kona lito bengal sdmshrike sdm660 sdm845),true)
+ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) lito bengal sdmshrike sdm660 sdm845),true)
 $(shell mkdir -p $(UAPI_OUT)/linux;)
 $(shell mkdir -p $(UAPI_OUT)/sound;)
 $(shell rm -rf $(PRODUCT_OUT)/obj/vendor/qcom/opensource/audio-kernel/ipc/Module.symvers)
@@ -57,7 +57,7 @@ $(shell rm -rf $(PRODUCT_OUT)/obj/vendor/qcom/opensource/audio-kernel/asoc/codec
 include $(MY_LOCAL_PATH)/asoc/codecs/rouleur/Android.mk
 endif
 
-ifeq ($(call is-board-platform-in-list, kona lito),true)
+ifeq ($(call is-board-platform-in-list, lito),true)
 $(shell rm -rf $(PRODUCT_OUT)/obj/vendor/qcom/opensource/audio-kernel/asoc/codecs/bolero/Module.symvers)
 include $(MY_LOCAL_PATH)/asoc/codecs/bolero/Android.mk
 $(shell rm -rf $(PRODUCT_OUT)/obj/vendor/qcom/opensource/audio-kernel/asoc/codecs/wcd938x/Module.symvers)

--- a/asoc/Android.mk
+++ b/asoc/Android.mk
@@ -26,11 +26,6 @@ TARGET := trinket
 AUDIO_SELECT  := CONFIG_SND_SOC_SM6150=m
 endif
 
-ifeq ($(call is-board-platform,kona),true)
-TARGET := kona
-AUDIO_SELECT  := CONFIG_SND_SOC_KONA=m
-endif
-
 ifeq ($(call is-board-platform,lito),true)
 TARGET := lito
 AUDIO_SELECT  := CONFIG_SND_SOC_LITO=m
@@ -53,7 +48,7 @@ AUDIO_SELECT  := CONFIG_SND_SOC_SDM845=m
 endif
 AUDIO_CHIPSET := audio
 # Build/Package only in case of supported target
-ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) kona lito bengal sdmshrike sdm660 sdm845),true)
+ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) lito bengal sdmshrike sdm660 sdm845),true)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/asoc/codecs/Android.mk
+++ b/asoc/codecs/Android.mk
@@ -27,10 +27,6 @@ ifeq ($(call is-board-platform,$(TRINKET)),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_SM6150=m
 endif
 
-ifeq ($(call is-board-platform,kona),true)
-AUDIO_SELECT  := CONFIG_SND_SOC_KONA=m
-endif
-
 ifeq ($(call is-board-platform,lito),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_LITO=m
 endif
@@ -45,7 +41,7 @@ endif
 
 AUDIO_CHIPSET := audio
 # Build/Package only in case of supported target
-ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) kona lito bengal sdmshrike sdm660 sdm845),true)
+ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) lito bengal sdmshrike sdm660 sdm845),true)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/asoc/codecs/awinic/Android.mk
+++ b/asoc/codecs/awinic/Android.mk
@@ -3,9 +3,6 @@
 # Assume no targets will be supported
 
 # Check if this driver needs be built for current target
-ifeq ($(call is-board-platform,kona),true)
-AUDIO_SELECT  := CONFIG_SND_SOC_KONA=m
-endif
 
 ifeq ($(call is-board-platform,lito),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_LITO=m
@@ -13,7 +10,7 @@ endif
 
 AUDIO_CHIPSET := audio
 # Build/Package only in case of supported target
-ifeq ($(call is-board-platform-in-list,kona lito),true)
+ifeq ($(call is-board-platform-in-list,lito),true)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/asoc/codecs/bolero/Android.mk
+++ b/asoc/codecs/bolero/Android.mk
@@ -7,10 +7,6 @@ ifeq ($(call is-board-platform,$(MSMSTEPPE) $(TRINKET)),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_SM6150=m
 endif
 
-ifeq ($(call is-board-platform,kona),true)
-AUDIO_SELECT  := CONFIG_SND_SOC_KONA=m
-endif
-
 ifeq ($(call is-board-platform,lito),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_LITO=m
 endif
@@ -21,7 +17,7 @@ endif
 
 AUDIO_CHIPSET := audio
 # Build/Package only in case of supported target
-ifeq ($(call is-board-platform-in-list,$(MSMSTEPPE) $(TRINKET) kona lito bengal),true)
+ifeq ($(call is-board-platform-in-list,$(MSMSTEPPE) $(TRINKET) lito bengal),true)
 
 LOCAL_PATH := $(call my-dir)
 
@@ -56,7 +52,7 @@ LOCAL_MODULE_DEBUG_ENABLE := true
 LOCAL_MODULE_PATH         := $(KERNEL_MODULES_OUT)
 include $(DLKM_DIR)/AndroidKernelModule.mk
 ###########################################################
-ifeq ($(call is-board-platform-in-list,$(MSMSTEPPE) $(TRINKET) kona lito),true)
+ifeq ($(call is-board-platform-in-list,$(MSMSTEPPE) $(TRINKET) lito),true)
 include $(CLEAR_VARS)
 LOCAL_MODULE              := $(AUDIO_CHIPSET)_wsa_macro.ko
 LOCAL_MODULE_KBUILD_NAME  := wsa_macro_dlkm.ko

--- a/asoc/codecs/wcd938x/Android.mk
+++ b/asoc/codecs/wcd938x/Android.mk
@@ -3,17 +3,13 @@
 # Assume no targets will be supported
 
 # Check if this driver needs be built for current target
-ifeq ($(call is-board-platform,kona),true)
-AUDIO_SELECT  := CONFIG_SND_SOC_KONA=m
-endif
-
 ifeq ($(call is-board-platform,lito),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_LITO=m
 endif
 
 AUDIO_CHIPSET := audio
 # Build/Package only in case of supported target
-ifeq ($(call is-board-platform-in-list,kona lito),true)
+ifeq ($(call is-board-platform-in-list,lito),true)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/dsp/Android.mk
+++ b/dsp/Android.mk
@@ -23,10 +23,6 @@ AUDIO_SELECT  := CONFIG_SND_SOC_SM6150=m
 endif
 endif
 
-ifeq ($(call is-board-platform, kona),true)
-AUDIO_SELECT  := CONFIG_SND_SOC_KONA=m
-endif
-
 ifeq ($(call is-board-platform, lito),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_LITO=m
 endif
@@ -41,7 +37,7 @@ endif
 
 AUDIO_CHIPSET := audio
 # Build/Package only in case of supported target
-ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) kona lito bengal sdmshrike sdm660 sdm845),true)
+ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) lito bengal sdmshrike sdm660 sdm845),true)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/dsp/codecs/Android.mk
+++ b/dsp/codecs/Android.mk
@@ -15,10 +15,6 @@ ifeq ($(call is-board-platform,$(MSMSTEPPE) $(TRINKET)),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_SM6150=m
 endif
 
-ifeq ($(call is-board-platform,kona),true)
-AUDIO_SELECT  := CONFIG_SND_SOC_KONA=m
-endif
-
 ifeq ($(call is-board-platform,lito),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_LITO=m
 endif
@@ -33,7 +29,7 @@ endif
 
 AUDIO_CHIPSET := audio
 # Build/Package only in case of supported target
-ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) kona lito bengal sdmshrike sdm660 sdm845),true)
+ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) lito bengal sdmshrike sdm660 sdm845),true)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/ipc/Android.mk
+++ b/ipc/Android.mk
@@ -23,10 +23,6 @@ AUDIO_SELECT  := CONFIG_SND_SOC_SM6150=m
 endif
 endif
 
-ifeq ($(call is-board-platform,kona),true)
-AUDIO_SELECT  := CONFIG_SND_SOC_KONA=m
-endif
-
 ifeq ($(call is-board-platform,lito),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_LITO=m
 endif
@@ -41,7 +37,7 @@ endif
 
 AUDIO_CHIPSET := audio
 # Build/Package only in case of supported target
-ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) kona lito bengal sdmshrike sdm660 sdm845),true)
+ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) lito bengal sdmshrike sdm660 sdm845),true)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/soc/Android.mk
+++ b/soc/Android.mk
@@ -23,10 +23,6 @@ AUDIO_SELECT  := CONFIG_SND_SOC_SM6150=m
 endif
 endif
 
-ifeq ($(call is-board-platform,kona),true)
-AUDIO_SELECT  := CONFIG_SND_SOC_KONA=m
-endif
-
 ifeq ($(call is-board-platform,lito),true)
 AUDIO_SELECT  := CONFIG_SND_SOC_LITO=m
 endif
@@ -41,7 +37,7 @@ endif
 
 AUDIO_CHIPSET := audio
 # Build/Package only in case of supported target
-ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) kona lito bengal sdmshrike sdm660 sdm845),true)
+ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) $(TRINKET) lito bengal sdmshrike sdm660 sdm845),true)
 
 LOCAL_PATH := $(call my-dir)
 
@@ -68,7 +64,7 @@ KBUILD_OPTIONS += BOARD_PLATFORM=$(TARGET_BOARD_PLATFORM)
 KBUILD_OPTIONS += $(AUDIO_SELECT)
 
 ###########################################################
-ifeq ($(call is-board-platform-in-list,$(MSMSTEPPE) $(TRINKET) kona lito bengal sdm660),true)
+ifeq ($(call is-board-platform-in-list,$(MSMSTEPPE) $(TRINKET) lito bengal sdm660),true)
 ifneq ($(TARGET_BOARD_AUTO),true)
 include $(CLEAR_VARS)
 LOCAL_MODULE              := $(AUDIO_CHIPSET)_pinctrl_lpi.ko
@@ -80,7 +76,7 @@ include $(DLKM_DIR)/AndroidKernelModule.mk
 endif
 endif
 ###########################################################
-ifeq ($(call is-board-platform-in-list,$(MSMSTEPPE) $(TRINKET) kona sdm660), true)
+ifeq ($(call is-board-platform-in-list,$(MSMSTEPPE) $(TRINKET) sdm660), true)
 ifneq ($(TARGET_BOARD_AUTO),true)
 include $(CLEAR_VARS)
 LOCAL_MODULE              := $(AUDIO_CHIPSET)_pinctrl_wcd.ko
@@ -110,7 +106,7 @@ LOCAL_MODULE_PATH         := $(KERNEL_MODULES_OUT)
 include $(DLKM_DIR)/AndroidKernelModule.mk
 endif
 ###########################################################
-ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) kona lito bengal sdmshrike),true)
+ifeq ($(call is-board-platform-in-list,msmnile $(MSMSTEPPE) lito bengal sdmshrike),true)
 ifneq ($(TARGET_PRODUCT), $(filter $(TARGET_PRODUCT), msmnile))
 include $(CLEAR_VARS)
 LOCAL_MODULE              := $(AUDIO_CHIPSET)_snd_event.ko


### PR DESCRIPTION
Some custom ROM (i.e. lineage os) use KONA := kona, which would result in these branch statements giving unexpected results.

This PR removes all hard-coded kona used for detecting the TARGET_BOARD_PLATFORM and hence preserves the behavior even if KONA := kona and TARGET_BOARD_PLATFORM := $(KONA).