### PR TITLE
Makefile: Ignore -Waddress error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,6 @@ ccflags_no-error_maybe_uninitialized := $(call cc-option,-Wno-error=maybe-uninit
 ccflags_no-error_misleading_indentation := $(call cc-option,-Wno-error=misleading-indentation)
 ccflags_no-error_restrict := $(call cc-option,-Wno-error=restrict)
 ccflags_no-error_array_bounds := $(call cc-option,-Wno-error=array-bounds)
+ccflags_no-error_address := $(call cc-option,-Wno-error=address)
 
-subdir-ccflags-y := $(ccflags_no-error_array_parameter) $(ccflags_no-error_maybe_uninitialized) $(ccflags_no-error_misleading_indentation) $(ccflags_no-error_restrict) $(ccflags_no-error_array_bounds)
+subdir-ccflags-y := $(ccflags_no-error_array_parameter) $(ccflags_no-error_maybe_uninitialized) $(ccflags_no-error_misleading_indentation) $(ccflags_no-error_restrict) $(ccflags_no-error_array_bounds) $(ccflags_no-error_address)


### PR DESCRIPTION
Newer compilers like GCC 12.0 have this warning make building failing
on messages like this:
techpack/audio/asoc/msm-pcm-routing-v2.c:1267:22: warning: the comparison will always evaluate as 'false' for the address of 'cal_data' will never be NULL [-Waddress]
 1267 |         if (cal_data == NULL)