### PR TITLE
[7.1] asoc: Don't check if a `static` array is `NULL` (`-Werror=address`)

### DIFF
--- a/asoc/msm-pcm-routing-v2.c
+++ b/asoc/msm-pcm-routing-v2.c
@@ -1130,6 +1130,9 @@ static int msm_routing_find_topology_on_index(int session_type, int app_type,
 	int topology = -EINVAL;
 	struct cal_block_data *cal_block = NULL;
 
+	if (cal_data[idx] == NULL)
+		return topology;
+
 	mutex_lock(&cal_data[idx]->lock);
 	cal_block = msm_routing_find_topology(session_type, app_type,
 					      acdb_dev_id, idx, exact);
@@ -1155,9 +1158,6 @@ static int msm_routing_get_adm_topology(int fedai_id, int session_type,
 	pr_debug("%s: fedai_id %d, session_type %d, be_id %d\n",
 	       __func__, fedai_id, session_type, be_id);
 
-	if (cal_data == NULL)
-		goto done;
-
 	app_type = fe_dai_app_type_cfg[fedai_id][session_type][be_id].app_type;
 	acdb_dev_id =
 		fe_dai_app_type_cfg[fedai_id][session_type][be_id].acdb_dev_id;
@@ -1179,7 +1179,6 @@ static int msm_routing_get_adm_topology(int fedai_id, int session_type,
 			topology = NULL_COPP_TOPOLOGY;
 	}
 
-done:
 	pr_debug("%s: Using topology %d\n", __func__, topology);
 	return topology;
 }


### PR DESCRIPTION
Closes #43

A `static` array (in the `.bss` section of a typical executable) always has a location in memory: it makes no sense to ever check for a `NULL` here.  Since this array holds pointers it was perhaps "intended" to check individual fields of this array before dereferencing, which we now do inside the `msm_routing_find_topology_on_index()` function.
