### PR TITLE
Makefile: Disable more warnings, found in recent compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,6 @@ ccflags_no-error_maybe_uninitialized := $(call cc-option,-Wno-error=maybe-uninit
 ccflags_no-error_misleading_indentation := $(call cc-option,-Wno-error=misleading-indentation)
 ccflags_no-error_restrict := $(call cc-option,-Wno-error=restrict)
 ccflags_no-error_array_bounds := $(call cc-option,-Wno-error=array-bounds)
+ccflags_no-error_frame-larger-than := $(call cc-option,-Wno-error=frame-larger-than=)
 
-subdir-ccflags-y := $(ccflags_no-error_array_parameter) $(ccflags_no-error_maybe_uninitialized) $(ccflags_no-error_misleading_indentation) $(ccflags_no-error_restrict) $(ccflags_no-error_array_bounds)
+subdir-ccflags-y := $(ccflags_no-error_array_parameter) $(ccflags_no-error_maybe_uninitialized) $(ccflags_no-error_misleading_indentation) $(ccflags_no-error_restrict) $(ccflags_no-error_array_bounds) $(ccflags_no-error_frame-larger-than)


### PR DESCRIPTION
Found testing with GCC 12.2.0.