### PR TITLE
asoc: Fix compilation

### DIFF
--- a/asoc/holi.c
+++ b/asoc/holi.c
@@ -755,7 +755,7 @@ static cpumask_t audio_cpu_map = CPU_MASK_NONE;
 static struct dev_pm_qos_request *msm_audio_req = NULL;
 static unsigned int qos_client_active_cnt = 0;
 
-static void msm_audio_add_qos_request()
+static void msm_audio_add_qos_request(void)
 {
 	int i;
 	int cpu = 0;
@@ -784,7 +784,7 @@ static void msm_audio_add_qos_request()
 	}
 }
 
-static void msm_audio_remove_qos_request()
+static void msm_audio_remove_qos_request(void)
 {
 	int cpu = 0;
 

--- a/asoc/msm_common.c
+++ b/asoc/msm_common.c
@@ -613,7 +613,7 @@ void msm_common_snd_shutdown(struct snd_pcm_substream *substream)
 	}
 }
 
-static void msm_audio_add_qos_request()
+static void msm_audio_add_qos_request(void)
 {
 	int i;
 	int cpu = 0;
@@ -641,7 +641,7 @@ static void msm_audio_add_qos_request()
 	}
 }
 
-static void msm_audio_remove_qos_request()
+static void msm_audio_remove_qos_request(void)
 {
 	int cpu = 0;
 


### PR DESCRIPTION
fix error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]