### PR TITLE
[9.16.r1] ASoC: codecs: aw882xx: Fix device type parse with AW_RENAME_ENABLE

### DIFF
--- a/asoc/codecs/aw882xx/aw882xx_bin_parse.c
+++ b/asoc/codecs/aw882xx/aw882xx_bin_parse.c
@@ -31,6 +31,8 @@
 #include <linux/cdev.h>
 #include <linux/list.h>
 #include <linux/string.h>
+#include <sound/soc.h>
+#include "aw882xx.h"
 #include "aw882xx_bin_parse.h"
 #include "aw882xx_device.h"
 #include "aw882xx_data_type.h"
@@ -804,13 +806,16 @@ static int aw_dev_parse_dev_type(struct aw_device *aw_dev,
 	int sec_num = 0;
 	struct aw_cfg_dde *cfg_dde =
 		(struct aw_cfg_dde *)((char *)prof_hdr + prof_hdr->a_hdr_offset);
+	struct aw882xx *aw882xx = dev_get_drvdata(aw_dev->dev);
 
 	aw_dev_info(aw_dev->dev, "enter");
 
 	for (i = 0; i < prof_hdr->a_ddt_num; i++) {
-		if ((aw_dev->i2c->adapter->nr == cfg_dde[i].dev_bus) &&
-			(aw_dev->i2c->addr == cfg_dde[i].dev_addr) &&
-			(cfg_dde[i].type == AW_DEV_TYPE_ID)) {
+		if (((aw_dev->i2c->adapter->nr == cfg_dde[i].dev_bus) &&
+			 (aw_dev->i2c->addr == cfg_dde[i].dev_addr) &&
+			 (cfg_dde[i].type == AW_DEV_TYPE_ID)) ||
+			((aw882xx->rename_flag == AW_RENAME_ENABLE) &&
+			 (cfg_dde[i].type == AW_DEV_TYPE_ID))) {
 			if (cfg_dde[i].data_type != ACF_SEC_TYPE_MONITOR) {
 				ret = aw_dev_parse_data_by_sec_type(aw_dev, prof_hdr, &cfg_dde[i],
 						&all_prof_info->prof_desc[cfg_dde[i].dev_profile]);

--- a/asoc/msm_dailink.h
+++ b/asoc/msm_dailink.h
@@ -1115,10 +1115,14 @@ SND_SOC_DAILINK_DEFS(tx_dma_tx4,
 	DAILINK_COMP_ARRAY(COMP_CODEC("bolero_codec", "tx_macro_tx2"),
 			   COMP_CODEC("wcd938x_codec", "wcd938x_cdc"),
 			   COMP_CODEC("wcd937x_codec", "wcd937x_cdc"),
+#ifdef ENABLE_SW_DMICS
 			   COMP_CODEC("swr-dmic.01", "swr_dmic_tx0"),
 			   COMP_CODEC("swr-dmic.02", "swr_dmic_tx1"),
 			   COMP_CODEC("swr-dmic.03", "swr_dmic_tx2"),
 			   COMP_CODEC("swr-dmic.04", "swr_dmic_tx3")),
+#else
+			   COMP_CODEC("msm-stub-codec.1", "msm-stub-rx")),
+#endif
 	DAILINK_COMP_ARRAY(COMP_PLATFORM("msm-pcm-routing")));
 
 SND_SOC_DAILINK_DEFS(va_dma_tx0,


### PR DESCRIPTION
Fix probing of the second aw882xx codec (the first one was probed because we were lucky. the bus number coincided with what is contained in the firmware) for Zambezi.
Disable soundwire DMICs.

PS. I withdraw my words that they brought their driver into shape:)