### PR TITLE
[9.12.r1] Seine mic fix

### DIFF
--- a/dsp/q6adm.c
+++ b/dsp/q6adm.c
@@ -3241,10 +3241,9 @@ int adm_open(int port_id, int path, int rate, int channel_mode, int topology,
 						this_adm.ec_ref_rx;
 					this_adm.ec_ref_rx = AFE_PORT_INVALID;
 				} else {
-					pr_err("%s: EC channels not set %d\n",
+					pr_warn("%s: EC channels not set %d\n",
 						__func__,
 						this_adm.num_ec_ref_rx_chans);
-					return -EINVAL;
 				}
 			}
 


### PR DESCRIPTION
Allow the number of ec reference channel is 0.
EC reference channel number could be zero in capture case.

Fixes audio capture on Seine.