### PR TITLE
[1.0.r1] ASoC: codecs: Rename qcom,is-used-swr-gpio

### DIFF
--- a/asoc/codecs/bolero/rx-macro.c
+++ b/asoc/codecs/bolero/rx-macro.c
@@ -4116,7 +4116,7 @@ static int rx_macro_probe(struct platform_device *pdev)
 	u8 bcl_pmic_params[3];
 	u32 default_clk_id = 0;
 	u32 is_used_rx_swr_gpio = 1;
-	const char *is_used_rx_swr_gpio_dt = "qcom,is-used-swr-gpio";
+	const char *is_used_rx_swr_gpio_dt = "qcom,swr-gpio-is-used";
 
 	if (!bolero_is_va_macro_registered(&pdev->dev)) {
 		dev_err(&pdev->dev,

--- a/asoc/codecs/bolero/tx-macro.c
+++ b/asoc/codecs/bolero/tx-macro.c
@@ -3417,7 +3417,7 @@ static int tx_macro_probe(struct platform_device *pdev)
 	int ret = 0;
 	const char *dmic_sample_rate = "qcom,tx-dmic-sample-rate";
 	u32 is_used_tx_swr_gpio = 1;
-	const char *is_used_tx_swr_gpio_dt = "qcom,is-used-swr-gpio";
+	const char *is_used_tx_swr_gpio_dt = "qcom,swr-gpio-is-used";
 	u32 disable_afe_wakeup_event_listener = 0;
 	const char *disable_afe_wakeup_event_listener_dt =
 			"qcom,disable-afe-wakeup-event-listener";

--- a/asoc/codecs/bolero/va-macro.c
+++ b/asoc/codecs/bolero/va-macro.c
@@ -3091,7 +3091,7 @@ static int va_macro_probe(struct platform_device *pdev)
 	u32 default_clk_id = 0;
 	struct clk *lpass_audio_hw_vote = NULL;
 	u32 is_used_va_swr_gpio = 0;
-	const char *is_used_va_swr_gpio_dt = "qcom,is-used-swr-gpio";
+	const char *is_used_va_swr_gpio_dt = "qcom,swr-gpio-is-used";
 
 	va_priv = devm_kzalloc(&pdev->dev, sizeof(struct va_macro_priv),
 			    GFP_KERNEL);

--- a/asoc/codecs/bolero/wsa-macro.c
+++ b/asoc/codecs/bolero/wsa-macro.c
@@ -3200,7 +3200,7 @@ static int wsa_macro_probe(struct platform_device *pdev)
 	int ret = 0;
 	u8 bcl_pmic_params[3];
 	u32 is_used_wsa_swr_gpio = 1;
-	const char *is_used_wsa_swr_gpio_dt = "qcom,is-used-swr-gpio";
+	const char *is_used_wsa_swr_gpio_dt = "qcom,swr-gpio-is-used";
 
 	if (!bolero_is_va_macro_registered(&pdev->dev)) {
 		dev_err(&pdev->dev,

--- a/asoc/codecs/lpass-cdc/lpass-cdc-rx-macro.c
+++ b/asoc/codecs/lpass-cdc/lpass-cdc-rx-macro.c
@@ -4709,7 +4709,7 @@ static int lpass_cdc_rx_macro_probe(struct platform_device *pdev)
 	u32 default_clk_id = 0;
 	struct clk *hifi_fir_clk = NULL;
 	u32 is_used_rx_swr_gpio = 1;
-	const char *is_used_rx_swr_gpio_dt = "qcom,is-used-swr-gpio";
+	const char *is_used_rx_swr_gpio_dt = "qcom,swr-gpio-is-used";
 
 	if (!lpass_cdc_is_va_macro_registered(&pdev->dev)) {
 		dev_err(&pdev->dev,

--- a/asoc/codecs/lpass-cdc/lpass-cdc-va-macro.c
+++ b/asoc/codecs/lpass-cdc/lpass-cdc-va-macro.c
@@ -2423,7 +2423,7 @@ static int lpass_cdc_va_macro_probe(struct platform_device *pdev)
 	u32 default_clk_id = 0;
 	struct clk *lpass_audio_hw_vote = NULL;
 	u32 is_used_va_swr_gpio = 0;
-	const char *is_used_va_swr_gpio_dt = "qcom,is-used-swr-gpio";
+	const char *is_used_va_swr_gpio_dt = "qcom,swr-gpio-is-used";
 
 	va_priv = devm_kzalloc(&pdev->dev, sizeof(struct lpass_cdc_va_macro_priv),
 			    GFP_KERNEL);

--- a/asoc/codecs/lpass-cdc/lpass-cdc-wsa-macro.c
+++ b/asoc/codecs/lpass-cdc/lpass-cdc-wsa-macro.c
@@ -3234,7 +3234,7 @@ static int lpass_cdc_wsa_macro_probe(struct platform_device *pdev)
 	char __iomem *wsa_io_base;
 	int ret = 0;
 	u32 is_used_wsa_swr_gpio = 1;
-	const char *is_used_wsa_swr_gpio_dt = "qcom,is-used-swr-gpio";
+	const char *is_used_wsa_swr_gpio_dt = "qcom,swr-gpio-is-used";
 
 	if (!lpass_cdc_is_va_macro_registered(&pdev->dev)) {
 		dev_err(&pdev->dev,

--- a/asoc/codecs/lpass-cdc/lpass-cdc-wsa2-macro.c
+++ b/asoc/codecs/lpass-cdc/lpass-cdc-wsa2-macro.c
@@ -3236,7 +3236,7 @@ static int lpass_cdc_wsa2_macro_probe(struct platform_device *pdev)
 	char __iomem *wsa2_io_base;
 	int ret = 0;
 	u32 is_used_wsa2_swr_gpio = 1;
-	const char *is_used_wsa2_swr_gpio_dt = "qcom,is-used-swr-gpio";
+	const char *is_used_wsa2_swr_gpio_dt = "qcom,swr-gpio-is-used";
 
 	if (!lpass_cdc_is_va_macro_registered(&pdev->dev)) {
 		dev_err(&pdev->dev,


### PR DESCRIPTION
Rename qcom,is-used-swr-gpio to qcom,swr-gpio-is-used because this
property has nothing to do with GPIO binding, moreover, this is a
simple bool flag, but it is implemented as u32. Let's leave it as
it is for now and get by with just renaming.
The change requires a corresponding renaming in the dts.

Fixes:
arch/arm64/boot/dts/qcom/parrot-audio-overlay.dtsi:28.29-78.4:
Warning (gpios_property): /fragment@16/__overlay__/va-macro@33F0000:
Missing property '#gpio-cells' in node /fragment@1/__overlay__/remoteproc-wpss@8a00000
or bad phandle (referred from qcom,is-used-swr-gpio[0])