### PR TITLE
[9.16.r1] Use extcon for MBHC

### DIFF
--- a/asoc/codecs/wcd-mbhc-adc.c
+++ b/asoc/codecs/wcd-mbhc-adc.c
@@ -1075,16 +1075,21 @@ static irqreturn_t wcd_mbhc_adc_hs_rem_irq(int irq, void *data)
 		WCD_MBHC_REG_UPDATE_BITS(WCD_MBHC_BTN_ISRC_CTL, 0);
 		mbhc->btn_press_intr = false;
 		mbhc->is_btn_press = false;
-		if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADSET)
+		if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADSET) {
 			wcd_mbhc_report_plug(mbhc, 0, SND_JACK_HEADSET);
-		else if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADPHONE)
+			extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_MICROPHONE, 0);
+		} else if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADPHONE) {
 			wcd_mbhc_report_plug(mbhc, 0, SND_JACK_HEADPHONE);
+			extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_HEADPHONE, 0);
+		} else if (mbhc->current_plug == MBHC_PLUG_TYPE_GND_MIC_SWAP) {
 #if IS_ENABLED(CONFIG_AUDIO_QGKI)
-		else if (mbhc->current_plug == MBHC_PLUG_TYPE_GND_MIC_SWAP)
 			wcd_mbhc_report_plug(mbhc, 0, SND_JACK_UNSUPPORTED);
 #endif /* CONFIG_AUDIO_QGKI */
-		else if (mbhc->current_plug == MBHC_PLUG_TYPE_HIGH_HPH)
+			extcon_set_state_sync(mbhc->extdev, EXTCON_MECHANICAL, 0);
+		} else if (mbhc->current_plug == MBHC_PLUG_TYPE_HIGH_HPH) {
 			wcd_mbhc_report_plug(mbhc, 0, SND_JACK_LINEOUT);
+			extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_LINE_OUT, 0);
+		}
 	} else {
 		/*
 		 * ADC COMPLETE and ELEC_REM interrupts are both enabled for

--- a/asoc/codecs/wcd-mbhc-legacy.c
+++ b/asoc/codecs/wcd-mbhc-legacy.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-/* Copyright (c) 2015-2020, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2015-2021, The Linux Foundation. All rights reserved.
  */
 #include <linux/module.h>
 #include <linux/init.h>
@@ -861,23 +861,28 @@ static irqreturn_t wcd_mbhc_hs_rem_irq(int irq, void *data)
 			WCD_MBHC_REG_UPDATE_BITS(WCD_MBHC_BTN_ISRC_CTL, 0);
 			mbhc->btn_press_intr = false;
 			mbhc->is_btn_press = false;
-			if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADSET)
+			if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADSET) {
 				wcd_mbhc_report_plug(
 					mbhc, 0, SND_JACK_HEADSET);
-			else if (mbhc->current_plug ==
+				extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_MICROPHONE, 0);
+			} else if (mbhc->current_plug ==
 					MBHC_PLUG_TYPE_HEADPHONE)
 				wcd_mbhc_report_plug(
 					mbhc, 0, SND_JACK_HEADPHONE);
-#if IS_ENABLED(CONFIG_AUDIO_QGKI)
-			else if (mbhc->current_plug ==
+				extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_HEADPHONE, 0);
+			} else if (mbhc->current_plug ==
 					MBHC_PLUG_TYPE_GND_MIC_SWAP)
+#if IS_ENABLED(CONFIG_AUDIO_QGKI)
 				wcd_mbhc_report_plug(
 					mbhc, 0, SND_JACK_UNSUPPORTED);
 #endif /* CONFIG_AUDIO_QGKI */
-			else if (mbhc->current_plug ==
-					MBHC_PLUG_TYPE_HIGH_HPH)
+				extcon_set_state_sync(mbhc->extdev, EXTCON_MECHANICAL, 0);
+			} else if (mbhc->current_plug ==
+					MBHC_PLUG_TYPE_HIGH_HPH) {
 				wcd_mbhc_report_plug(
 					mbhc, 0, SND_JACK_LINEOUT);
+				extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_LINE_OUT, 0);
+			}
 		} else {
 			if (!(hphl_sch && mic_sch && hs_comp_result)) {
 				/*

--- a/asoc/codecs/wcd-mbhc-v2.c
+++ b/asoc/codecs/wcd-mbhc-v2.c
@@ -2107,18 +2107,19 @@ int wcd_mbhc_init(struct wcd_mbhc *mbhc, struct snd_soc_component *component,
 		       mbhc->intr_ids->hph_right_ocp);
 		goto err_hphr_ocp_irq;
 	}
-	if (!mbhc->extdev)
+	if (!mbhc->extdev) {
 		mbhc->extdev =
 			devm_extcon_dev_allocate(component->dev,
 				mbhc_ext_dev_supported_table);
-	if (IS_ERR(mbhc->extdev)) {
-		goto err_ext_dev;
-		ret = PTR_ERR(mbhc->extdev);
-	}
-	ret = devm_extcon_dev_register(component->dev, mbhc->extdev);
-	if (ret) {
-		pr_err("%s:audio registration failed\n", __func__);
-		goto err_ext_dev;
+		if (IS_ERR(mbhc->extdev)) {
+			goto err_ext_dev;
+			ret = PTR_ERR(mbhc->extdev);
+		}
+		ret = devm_extcon_dev_register(component->dev, mbhc->extdev);
+		if (ret) {
+			pr_err("%s:audio registration failed\n", __func__);
+			goto err_ext_dev;
+		}
 	}
 
 #if defined(CONFIG_ARCH_SONY_SAGAMI) || \
@@ -2167,9 +2168,6 @@ EXPORT_SYMBOL(wcd_mbhc_init);
 void wcd_mbhc_deinit(struct wcd_mbhc *mbhc)
 {
 	struct snd_soc_component *component = mbhc->component;
-
-	if (mbhc->extdev)
-		devm_extcon_dev_unregister(component->dev, mbhc->extdev);
 
 	mbhc->mbhc_cb->free_irq(component, mbhc->intr_ids->mbhc_sw_intr, mbhc);
 	mbhc->mbhc_cb->free_irq(component, mbhc->intr_ids->mbhc_btn_press_intr,

--- a/asoc/codecs/wcd-mbhc-v2.c
+++ b/asoc/codecs/wcd-mbhc-v2.c
@@ -35,6 +35,14 @@ struct mutex hphr_pa_lock;
 struct wcd_mbhc *mbhc_local;
 #endif
 
+static const unsigned int mbhc_ext_dev_supported_table[] = {
+	EXTCON_JACK_MICROPHONE,
+	EXTCON_JACK_HEADPHONE,
+	EXTCON_JACK_LINE_OUT,
+	EXTCON_MECHANICAL,
+	EXTCON_NONE,
+};
+
 void wcd_mbhc_jack_report(struct wcd_mbhc *mbhc,
 			  struct snd_soc_jack *jack, int status, int mask)
 {
@@ -568,6 +576,7 @@ void wcd_mbhc_report_plug(struct wcd_mbhc *mbhc, int insertion,
 	struct snd_soc_component *component = mbhc->component;
 	bool is_pa_on = false;
 	u8 fsm_en = 0;
+	int extdev_type = 0;
 #if defined(CONFIG_ARCH_SONY_SAGAMI) || \
 	defined(CONFIG_ARCH_SONY_MURRAY) || defined(CONFIG_ARCH_SONY_ZAMBEZI)
 	bool skip_report = false;
@@ -663,6 +672,16 @@ void wcd_mbhc_report_plug(struct wcd_mbhc *mbhc, int insertion,
 					 __func__, mbhc->hph_status);
 				wcd_mbhc_jack_report(mbhc, &mbhc->headset_jack,
 					0, WCD_MBHC_JACK_MASK);
+				if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADPHONE)
+					extdev_type = EXTCON_JACK_HEADPHONE;
+				else if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADSET)
+					extdev_type = EXTCON_JACK_MICROPHONE;
+				else if (mbhc->current_plug == MBHC_PLUG_TYPE_HIGH_HPH)
+					extdev_type = EXTCON_JACK_LINE_OUT;
+				else if (mbhc->current_plug == MBHC_PLUG_TYPE_GND_MIC_SWAP)
+					extdev_type = EXTCON_MECHANICAL;
+
+				extcon_set_state_sync(mbhc->extdev, extdev_type, 0);
 			}
 			if (mbhc->hph_status == SND_JACK_LINEOUT) {
 
@@ -819,6 +838,7 @@ void wcd_mbhc_elec_hs_report_unplug(struct wcd_mbhc *mbhc)
 
 	pr_debug("%s: Report extension cable\n", __func__);
 	wcd_mbhc_report_plug(mbhc, 1, SND_JACK_LINEOUT);
+	extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_LINE_OUT, 1);
 	/*
 	 * If PA is enabled HPHL schmitt trigger can
 	 * be unreliable, make sure to disable it
@@ -849,6 +869,7 @@ void wcd_mbhc_find_plug_and_report(struct wcd_mbhc *mbhc,
 {
 	bool anc_mic_found = false;
 	enum snd_jack_types jack_type;
+	int ret = 0;
 
 	if (mbhc->deinit_in_progress) {
 		pr_info("%s: mbhc deinit in progess: ignore report\n", __func__);
@@ -871,14 +892,20 @@ void wcd_mbhc_find_plug_and_report(struct wcd_mbhc *mbhc,
 		 * report a headphone or unsupported
 		 */
 		wcd_mbhc_report_plug(mbhc, 1, SND_JACK_HEADPHONE);
+		ret = extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_HEADPHONE, 1);
 	} else if (plug_type == MBHC_PLUG_TYPE_GND_MIC_SWAP) {
-		if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADPHONE)
+		if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADPHONE) {
 			wcd_mbhc_report_plug(mbhc, 0, SND_JACK_HEADPHONE);
-		if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADSET)
+			ret = extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_HEADPHONE, 0);
+		}
+		if (mbhc->current_plug == MBHC_PLUG_TYPE_HEADSET) {
 			wcd_mbhc_report_plug(mbhc, 0, SND_JACK_HEADSET);
+			ret = extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_MICROPHONE, 0);
+		}
 #if IS_ENABLED(CONFIG_AUDIO_QGKI)
 		wcd_mbhc_report_plug(mbhc, 1, SND_JACK_UNSUPPORTED);
 #endif /* CONFIG_AUDIO_QGKI */
+		ret = extcon_set_state_sync(mbhc->extdev, EXTCON_MECHANICAL, 1);
 	} else if (plug_type == MBHC_PLUG_TYPE_HEADSET) {
 		if (mbhc->mbhc_cfg->enable_anc_mic_detect &&
 		    mbhc->mbhc_fn->wcd_mbhc_detect_anc_plug_type)
@@ -891,10 +918,12 @@ void wcd_mbhc_find_plug_and_report(struct wcd_mbhc *mbhc,
 		 * only report the mic line
 		 */
 		wcd_mbhc_report_plug(mbhc, 1, jack_type);
+		ret = extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_MICROPHONE, 1);
 	} else if (plug_type == MBHC_PLUG_TYPE_HIGH_HPH) {
 		if (mbhc->mbhc_cfg->detect_extn_cable) {
 			/* High impedance device found. Report as LINEOUT */
 			wcd_mbhc_report_plug(mbhc, 1, SND_JACK_LINEOUT);
+			ret = extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_LINE_OUT, 1);
 			pr_debug("%s: setup mic trigger for further detection\n",
 				 __func__);
 
@@ -914,6 +943,7 @@ void wcd_mbhc_find_plug_and_report(struct wcd_mbhc *mbhc,
 					     true);
 		} else {
 			wcd_mbhc_report_plug(mbhc, 1, SND_JACK_LINEOUT);
+			ret = extcon_set_state_sync(mbhc->extdev, EXTCON_JACK_LINE_OUT, 1);
 		}
 	} else {
 		WARN(1, "Unexpected current plug_type %d, plug_type %d\n",
@@ -961,6 +991,7 @@ static void wcd_mbhc_swch_irq_handler(struct wcd_mbhc *mbhc)
 	bool micbias1 = false;
 	struct snd_soc_component *component = mbhc->component;
 	enum snd_jack_types jack_type;
+	int extdev_type = 0;
 
 	dev_dbg(component->dev, "%s: enter\n", __func__);
 	WCD_MBHC_RSC_LOCK(mbhc);
@@ -1048,12 +1079,16 @@ static void wcd_mbhc_swch_irq_handler(struct wcd_mbhc *mbhc)
 		switch (mbhc->current_plug) {
 		case MBHC_PLUG_TYPE_HEADPHONE:
 			jack_type = SND_JACK_HEADPHONE;
+			extdev_type = EXTCON_JACK_HEADPHONE;
 			break;
-#if IS_ENABLED(CONFIG_AUDIO_QGKI)
 		case MBHC_PLUG_TYPE_GND_MIC_SWAP:
+#if IS_ENABLED(CONFIG_AUDIO_QGKI)
 			jack_type = SND_JACK_UNSUPPORTED;
-			break;
+#else
+			jack_type = SND_JACK_HEADPHONE;
 #endif /* CONFIG_AUDIO_QGKI */
+			extdev_type = EXTCON_MECHANICAL;
+			break;
 		case MBHC_PLUG_TYPE_HEADSET:
 			/* make sure to turn off Rbias */
 			if (mbhc->mbhc_cb->micb_internal)
@@ -1062,12 +1097,14 @@ static void wcd_mbhc_swch_irq_handler(struct wcd_mbhc *mbhc)
 			/* Pulldown micbias */
 			WCD_MBHC_REG_UPDATE_BITS(WCD_MBHC_PULLDOWN_CTRL, 1);
 			jack_type = SND_JACK_HEADSET;
+			extdev_type = EXTCON_JACK_MICROPHONE;
 			break;
 		case MBHC_PLUG_TYPE_HIGH_HPH:
 			if (mbhc->mbhc_detection_logic == WCD_DETECTION_ADC)
 			    WCD_MBHC_REG_UPDATE_BITS(WCD_MBHC_ELECT_ISRC_EN, 0);
 			mbhc->is_extn_cable = false;
 			jack_type = SND_JACK_LINEOUT;
+			extdev_type = EXTCON_JACK_LINE_OUT;
 			break;
 		default:
 			pr_info("%s: Invalid current plug: %d\n",
@@ -1077,6 +1114,7 @@ static void wcd_mbhc_swch_irq_handler(struct wcd_mbhc *mbhc)
 #else
 			jack_type = SND_JACK_HEADPHONE;
 #endif /* CONFIG_AUDIO_QGKI */
+			extdev_type = EXTCON_MECHANICAL;
 			break;
 		}
 		wcd_mbhc_hs_elec_irq(mbhc, WCD_MBHC_ELEC_HS_REM, false);
@@ -1085,6 +1123,7 @@ static void wcd_mbhc_swch_irq_handler(struct wcd_mbhc *mbhc)
 		WCD_MBHC_REG_UPDATE_BITS(WCD_MBHC_ELECT_SCHMT_ISRC, 0);
 		mbhc->extn_cable_hph_rem = false;
 		wcd_mbhc_report_plug(mbhc, 0, jack_type);
+		extcon_set_state_sync(mbhc->extdev, extdev_type, 0);
 
 		if (mbhc->mbhc_cfg->enable_usbc_analog) {
 			WCD_MBHC_REG_UPDATE_BITS(WCD_MBHC_L_DET_EN, 0);
@@ -2068,6 +2107,19 @@ int wcd_mbhc_init(struct wcd_mbhc *mbhc, struct snd_soc_component *component,
 		       mbhc->intr_ids->hph_right_ocp);
 		goto err_hphr_ocp_irq;
 	}
+	if (!mbhc->extdev)
+		mbhc->extdev =
+			devm_extcon_dev_allocate(component->dev,
+				mbhc_ext_dev_supported_table);
+	if (IS_ERR(mbhc->extdev)) {
+		goto err_ext_dev;
+		ret = PTR_ERR(mbhc->extdev);
+	}
+	ret = devm_extcon_dev_register(component->dev, mbhc->extdev);
+	if (ret) {
+		pr_err("%s:audio registration failed\n", __func__);
+		goto err_ext_dev;
+	}
 
 #if defined(CONFIG_ARCH_SONY_SAGAMI) || \
 	defined(CONFIG_ARCH_SONY_MURRAY) || defined(CONFIG_ARCH_SONY_ZAMBEZI)
@@ -2083,6 +2135,8 @@ int wcd_mbhc_init(struct wcd_mbhc *mbhc, struct snd_soc_component *component,
 	pr_debug("%s: leave ret %d\n", __func__, ret);
 	return ret;
 
+err_ext_dev:
+	mbhc->mbhc_cb->free_irq(component, mbhc->intr_ids->hph_right_ocp, mbhc);
 err_hphr_ocp_irq:
 	mbhc->mbhc_cb->free_irq(component, mbhc->intr_ids->hph_left_ocp, mbhc);
 err_hphl_ocp_irq:
@@ -2113,6 +2167,9 @@ EXPORT_SYMBOL(wcd_mbhc_init);
 void wcd_mbhc_deinit(struct wcd_mbhc *mbhc)
 {
 	struct snd_soc_component *component = mbhc->component;
+
+	if (mbhc->extdev)
+		devm_extcon_dev_unregister(component->dev, mbhc->extdev);
 
 	mbhc->mbhc_cb->free_irq(component, mbhc->intr_ids->mbhc_sw_intr, mbhc);
 	mbhc->mbhc_cb->free_irq(component, mbhc->intr_ids->mbhc_btn_press_intr,

--- a/include/asoc/wcd-mbhc-v2.h
+++ b/include/asoc/wcd-mbhc-v2.h
@@ -7,6 +7,8 @@
 #include <linux/wait.h>
 #include <linux/stringify.h>
 #include <linux/power_supply.h>
+#include <linux/extcon.h>
+#include <linux/extcon-provider.h>
 #include "wcdcal-hwdep.h"
 #include <sound/jack.h>
 
@@ -627,6 +629,8 @@ struct wcd_mbhc {
 	bool force_linein;
 	struct device_node *fsa_np;
 	struct notifier_block fsa_nb;
+
+	struct extcon_dev *extdev;
 };
 
 void wcd_mbhc_find_plug_and_report(struct wcd_mbhc *mbhc,


### PR DESCRIPTION
Add support for jack insertion reporting using Extcon framework.

Completes: https://github.com/sonyxperiadev/device-sony-common/pull/947

Tested on: Sagami PDX214